### PR TITLE
install the correct paho-mqtt version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     asyncio-mqtt
     bleak
     crcmod
+    paho-mqtt ==1.6.1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Paho v2.0 is not backwards compatible, this requires 1.6.1 be installed.